### PR TITLE
Fix/reports bug

### DIFF
--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -13,7 +13,7 @@ function verifyJwt(req, res, next) {
   let signedToken = authorization.slice(7);
 
   try {
-    const orderId = jwt.verify(signedToken, TOKEN_SIGNING_KEY);
+    const { order_id: orderId } = jwt.verify(signedToken, TOKEN_SIGNING_KEY)
     req.orderId = orderId;
     next();
   } catch (err) {

--- a/app/routes/healthReports.js
+++ b/app/routes/healthReports.js
@@ -73,7 +73,7 @@ async function createHealthReport (req, res) {
 
     try {
       await HealthReportService.addHealthReport(healthReport)
-      console.log(`Successfully created health report: ${JSON.parse(healthReport)}`) 
+      console.log(`Successfully created health report: ${healthReport}`) 
     } catch (err) {
       throw new DbError(err)
     }

--- a/app/routes/locationReports.js
+++ b/app/routes/locationReports.js
@@ -59,7 +59,7 @@ async function createLocationReport (req, res) {
       metadata 
     }
     await LocationReportService.addLocationReport(locationReport)
-    console.log(`Successfully created location report: ${JSON.parse(locationReport)}`) 
+    console.log(`Successfully created location report: ${locationReport}`) 
 
     res.status(200).send('Ok')
   } catch (err) {


### PR DESCRIPTION
This PR fixes the bug in the auth middleware function `verifyJwt`. 

### Details
In writing the middleware, I had previously assumed that `jwt.verify(signedToken, TOKEN_SIGNING_KEY)` returned the `order_id` field. However, the `jwt.verify` method returns an object containing `order_id` as a field inside it. This caused a schema validation bug that was caught by our AJV validator - this PR fixes that.

Additionally, this PR removes the unnecessary use of `JSON.parse` in some logging stateemnts.