### PR TITLE
feat: add auth for all routes

### DIFF
--- a/app/errors/AuthErrors.js
+++ b/app/errors/AuthErrors.js
@@ -6,6 +6,13 @@ class InvalidAdminUserError extends ApplicationError {
   }
 }
 
+class UnauthorisedActionError extends ApplicationError {
+  constructor(action, resource) {
+    super(`This user is not allowed to ${action} for ${resource}`, 401);
+  }
+}
+
 module.exports = {
   InvalidAdminUserError,
+  UnauthorisedActionError
 };

--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,7 @@ const { PORT } = process.env;
 const env = process.env.NODE_ENV ? process.env.NODE_ENV : 'development'
 
 const db = require('./src/models')
+const { verifyJwt } = require('./middlewares/auth')
 
 const app = express();
 app.use(express.json());
@@ -55,12 +56,16 @@ app.use(cors({
   credentials: true,
 }));
 
+app.use('/otp', otpRouter);
+
+// Auth middleware
+app.use(verifyJwt);
+
 // Protected routes
 app.use('/health-reports', healthReportsRouter);
 app.use('/location-reports', locationReportsRouter);
 app.use('/push-notifications', pushNotificationsRouter);
 app.use('/orders', ordersRouter);
-app.use('/otp', otpRouter);
 app.use('/photos', photosRouter);
 
 db.sequelize.sync().then(() => {

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -37,8 +37,9 @@ function verifyJwt (req, res, next) {
         throw new InvalidAdminUserError();
       }
     } else {
-      const { order_id: orderId } = tokenData;
+      const { order_id: orderId, role} = tokenData;
       req.orderId = orderId;
+      req.role = role;
     }
     next();
   } catch (err) {

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -7,46 +7,53 @@ const { InvalidAdminUserError } = require('../errors/AuthErrors');
 // Constants
 const { TOKEN_SIGNING_KEY } = process.env;
 
-function verifyJwt(isAdmin = false) {
-  // eslint-disable-next-line consistent-return
-  const verifyJwtMiddleware = (req, res, next) => {
-    const { authorization } = req.headers;
+const adminOnlyRoute = ['/orders']
 
-    if (!authorization || !authorization.startsWith('Bearer ')) {
-      return res.status(401).send('Unauthorized');
+function verifyJwt (req, res, next) {
+  const { authorization } = req.headers;
+
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return res.status(401).send('Unauthorized');
+  }
+
+  // Remove 'Bearer ' from authorization header
+  const signedToken = authorization.slice(7);
+
+  // Extract baseUrl from req
+  // Express req.baseUrl is not available in middleware
+  const startIdx = 0
+  let endIdx = startIdx + 1
+  while (req.originalUrl[endIdx] !== '/' && endIdx < req.originalUrl.length) {
+    endIdx++
+  }
+  req.baseUrl = req.originalUrl.slice(startIdx, endIdx)
+
+  const isAdminOnlyPath = adminOnlyRoute.includes(req.baseUrl)
+
+  try {
+    const tokenData = jwt.verify(signedToken, TOKEN_SIGNING_KEY);
+    if (isAdminOnlyPath) {
+      if (tokenData.role !== 'admin') {
+        throw new InvalidAdminUserError();
+      }
+    } else {
+      const { order_id: orderId } = tokenData;
+      req.orderId = orderId;
     }
+    next();
+  } catch (err) {
+    console.error('Error authenticating', err, JSON.stringify(req.headers));
 
-    // Remove 'Bearer ' from authorization header
-    const signedToken = authorization.slice(7);
-
-
-    try {
-      const tokenData = jwt.verify(signedToken, TOKEN_SIGNING_KEY);
-      if (isAdmin) {
-        if (tokenData.role !== 'admin') {
-          throw new InvalidAdminUserError();
-        }
-      } else {
-        const { order_id: orderId } = tokenData;
-        req.orderId = orderId;
-      }
-      next();
-    } catch (err) {
-      console.error('Error authenticating', err, JSON.stringify(req.headers));
-
-      if (err instanceof jwt.TokenExpiredError) {
-        return res.status(401).send('Token expired');
-      }
-      if (err instanceof jwt.JsonWebTokenError) {
-        return res.status(400).send('Malformed JWT');
-      }
-      if (err instanceof InvalidAdminUserError) {
-        return res.status(err.status).send(err.message);
-      }
+    if (err instanceof jwt.TokenExpiredError) {
+      return res.status(401).send('Token expired');
     }
-  };
-
-  return verifyJwtMiddleware;
-}
+    if (err instanceof jwt.JsonWebTokenError) {
+      return res.status(400).send('Malformed JWT');
+    }
+    if (err instanceof InvalidAdminUserError) {
+      return res.status(err.status).send(err.message);
+    }
+  }
+};
 
 module.exports = { verifyJwt };

--- a/app/routes/healthReports.js
+++ b/app/routes/healthReports.js
@@ -5,7 +5,6 @@ const router = express.Router();
 
 // Middlewares
 const Ajv = require('ajv');
-const { verifyJwt } = require('../middlewares/auth');
 
 // Services
 const { HealthReportService } = require('../services/HealthReportService');
@@ -87,6 +86,6 @@ async function createHealthReport(req, res) {
 }
 
 router.get('/:order_id', getHealthReports);
-router.post('/', verifyJwt, createHealthReport);
+router.post('/', createHealthReport);
 
 module.exports = router;

--- a/app/routes/healthReports.js
+++ b/app/routes/healthReports.js
@@ -15,6 +15,7 @@ const { getHealthReportsSchema, createHealthReportSchema } = require('../validat
 
 // Errors
 const { DbError } = require('../errors/DbErrors');
+const { UnauthorisedActionError } = require('../errors/AuthErrors');
 const { InputSchemaValidationError } = require('../errors/InputValidationErrors');
 
 async function getHealthReports(req, res) {
@@ -25,17 +26,21 @@ async function getHealthReports(req, res) {
 
     const { order_id: orderId } = req.params;
 
-    // 2. Find all locationReport objects that have the specified orderId
-    let healthReportsForOrder;
-    try {
-      healthReportsForOrder = await HealthReportService.getAllHealthReports(orderId);
-      console.log(`Successfully obtained health reports for orderId: ${orderId}`);
-    } catch (err) {
-      throw new DbError(err);
-    }
+    if ((req.orderId && req.orderId === orderId) || req.role === 'admin') {
+      // 2. Find all locationReport objects that have the specified orderId
+      let healthReportsForOrder;
+      try {
+        healthReportsForOrder = await HealthReportService.getAllHealthReports(orderId);
+        console.log(`Successfully obtained health reports for orderId: ${orderId}`);
+      } catch (err) {
+        throw new DbError(err);
+      }
 
-    const { healthReports } = healthReportsForOrder;
-    res.status(200).send({ health_reports: healthReports });
+      const { healthReports } = healthReportsForOrder;
+      res.status(200).send({ health_reports: healthReports });
+    } else {
+      throw new UnauthorisedActionError('get health reports', orderId)
+    }
   } catch (err) {
     console.error(`GET /health-reports failed with err: ${err}`);
     res.status(500).send(err.message);

--- a/app/routes/locationReports.js
+++ b/app/routes/locationReports.js
@@ -5,7 +5,6 @@ const router = express.Router();
 
 // Middlewares
 const Ajv = require('ajv');
-const { verifyJwt } = require('../middlewares/auth');
 
 // Services
 const { LocationReportService } = require('../services/LocationReportService');
@@ -70,6 +69,6 @@ async function createLocationReport(req, res) {
 }
 
 router.get('/:order_id', getLocationReports);
-router.post('/', verifyJwt, createLocationReport);
+router.post('/', createLocationReport);
 
 module.exports = router;

--- a/app/src/seeders/20200404203500-add-admin-users.js
+++ b/app/src/seeders/20200404203500-add-admin-users.js
@@ -4,13 +4,13 @@ module.exports = {
     [
       {
         id: 1,
-        email: 'test@some-agency.gov.sg',
+        email: 'test@agency.gov.sg',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         id: 2,
-        email: 'homer@some-agency.gov.sg',
+        email: 'homer@agency.gov.sg',
         createdAt: new Date(),
         updatedAt: new Date(),
       },


### PR DESCRIPTION
This PR introduces the auth middleware for all routes except `/ping` (healthcheck) and `/otp` 

## Changes to `/middleware/auth.js`
- an array of admin only routes (currently just `/orders`) is added
- the `baseUrl` is extracted from `req.originalUrl` as Express `req.baseUrl` is not accessible within middleware
- a check is performed to determine whether the baseUrl is an admin only route, if it is then the `role` attribute of the verified JWT is checked
- the `role` extracted from the JWT is also added as an attribute to the `req` object for use within the routes layer

## Changes to `app/index.js`
- the middleware is mounted in front of all protected routes

## Changes to `getHealthReports` and `getLocationReports`
- in order to prevent regular users from accessing report data of other regular users if they happen to obtain the quarantine order ID, an additional check is included in the route layer method to determine whether the order ID extracted from the JWT (`req.orderId`) is equal to the `req.params.order_id` being requested OR the role extracted from the JWT is `admin` as admin users can view reports across all users