### PR TITLE
show 401 for malformed jwt

### DIFF
--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -49,7 +49,7 @@ function verifyJwt (req, res, next) {
       return res.status(401).send('Token expired');
     }
     if (err instanceof jwt.JsonWebTokenError) {
-      return res.status(401).send('Malformed JWT');
+      return res.status(401).send(`Unauthorized. ${err.message}`);
     }
     if (err instanceof InvalidAdminUserError) {
       return res.status(err.status).send(err.message);

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -49,7 +49,7 @@ function verifyJwt (req, res, next) {
       return res.status(401).send('Token expired');
     }
     if (err instanceof jwt.JsonWebTokenError) {
-      return res.status(400).send('Malformed JWT');
+      return res.status(401).send('Malformed JWT');
     }
     if (err instanceof InvalidAdminUserError) {
       return res.status(err.status).send(err.message);


### PR DESCRIPTION
Currently our token signing secret is smaller than the 256-bit
recommendation by RFC7518 <https://tools.ietf.org/html/rfc7518#page-7>.

When we do change the secret to be more secure, all the previously
issued token will be considered malformed, hence it'd be better to send
a 401 Authorization error to the frontend for the frontend to go back to
the register mobile screen

Once PR is merged in, we should change the token signing key to be 256/512 bits